### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ There are three files which differ from the regular modules. Please have a look 
 - [variables.less](assets/less/theme/variables.less)  
 	Used to override bootstrap variables. Make sure to read the comments which describe how to handle this file which can save you lots of time when it comes to a Bootstrap update.
 - [mixins.less](assets/less/theme/mixins.less)  
-	Holds additional global mixins which are meant to be used accross modules.
+	Holds additional global mixins which are meant to be used across modules.
 - [scaffolding.less](assets/less/theme/scaffolding.less)  
 	Used to define the most generic html elements. 
 


### PR DESCRIPTION
@micromata, I've corrected a typographical error in the documentation of the [bootstrap-kickstart](https://github.com/micromata/bootstrap-kickstart) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.