### PR TITLE
Update ESLint config

### DIFF
--- a/assets/js/.eslintrc
+++ b/assets/js/.eslintrc
@@ -6,6 +6,7 @@
   "rules": {
     "operator-assignment": ["off"],
     "eqeqeq": ["error", "allow-null"],
-    "no-eq-null": ["off"]
+    "no-eq-null": ["off"],
+    "quote-props": ["error", "as-needed"]
   }
 }

--- a/assets/js/.eslintrc
+++ b/assets/js/.eslintrc
@@ -2,5 +2,8 @@
   "env": {
     "browser": true,
     "jquery": true
+  },
+  "rules": {
+    "operator-assignment": ["off"]
   }
 }

--- a/assets/js/.eslintrc
+++ b/assets/js/.eslintrc
@@ -4,6 +4,8 @@
     "jquery": true
   },
   "rules": {
-    "operator-assignment": ["off"]
+    "operator-assignment": ["off"],
+    "eqeqeq": ["error", "allow-null"],
+    "no-eq-null": ["off"]
   }
 }


### PR DESCRIPTION
I changed the follwing;

* Allow developers to choose which style is more readable on a case-by-case basis.
  * See http://eslint.org/docs/rules/operator-assignment
* Allow comparison against `null` and `undefined`  in a single expression.
  * See http://eslint.org/docs/rules/eqeqeq and http://eslint.org/docs/rules/no-eq-null
* Allow inconsistent quoting of object properties
  * See http://eslint.org/docs/rules/quote-props#options

I guess the second one isn’t possible by default for that unexperienced people don’t get trapped by that. But I like to be able to check for `null` or `undefined` with:
```javascript
if (foo == null) {
  // foo is null or undefined
} 
```

Any opionions on that? @krnlde @revrng 