### PR TITLE
Making sourcemaps in .js production files optional

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,11 @@ module.exports = function (grunt) {
 			reports: 'reports',
 			docs: 'docs',
 			server: 'server',
-			banner: '',
+			banner: '/*! <%= pkg.title %> - v<%= pkg.version %>\n' +
+					' * <%= pkg.author.email %>\n' +
+					' * Copyright ©<%= grunt.template.today("yyyy") %> <%= pkg.author.name %>\n' +
+					' * <%= grunt.template.today("yyyy-mm-dd") %>\n' +
+					' */',
 			includeSourcemaps: false
 		},
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
 					' * Copyright ©<%= grunt.template.today("yyyy") %> <%= pkg.author.name %>\n' +
 					' * <%= grunt.template.today("yyyy-mm-dd") %>\n' +
 					' */',
-			includeSourcemaps: false
+			includeSourceMaps: false
 		},
 
 		// List available tasks
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
 		uglify: {
 			options: {
 				banner: '<%= config.banner %>',
-				sourceMap: '<%= config.includeSourcemaps %>',
+				sourceMap: '<%= config.includeSourceMaps %>',
 				sourceMapIncludeSources: true,
 				compress: {
 					drop_console: true, // eslint-disable-line camelcase
@@ -136,7 +136,7 @@ module.exports = function (grunt) {
 			},
 			bower: {
 				options: {
-					sourceMap: '<%= config.includeSourcemaps %>',
+					sourceMap: '<%= config.includeSourceMaps %>',
 					banner: '<%= config.banner %>'
 				},
 				files: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,11 +27,8 @@ module.exports = function (grunt) {
 			reports: 'reports',
 			docs: 'docs',
 			server: 'server',
-			banner: '/*! <%= pkg.title %> - v<%= pkg.version %>\n' +
-				' * <%= pkg.author.email %>\n' +
-				' * Copyright ©<%= grunt.template.today("yyyy") %> <%= pkg.author.name %>\n' +
-				' * <%= grunt.template.today("yyyy-mm-dd") %>\n' +
-				' */'
+			banner: '',
+			includeSourcemaps: false
 		},
 
 		// List available tasks
@@ -117,7 +114,7 @@ module.exports = function (grunt) {
 		uglify: {
 			options: {
 				banner: '<%= config.banner %>',
-				sourceMap: true,
+				sourceMap: '<%= config.includeSourcemaps %>',
 				sourceMapIncludeSources: true,
 				compress: {
 					drop_console: true, // eslint-disable-line camelcase
@@ -135,8 +132,8 @@ module.exports = function (grunt) {
 			},
 			bower: {
 				options: {
-					sourceMap: false,
-					banner: '<%= config.banner %>\n'
+					sourceMap: '<%= config.includeSourcemaps %>',
+					banner: '<%= config.banner %>'
 				},
 				files: {
 					'<%= config.dist %>/libs/libs.min.js': ['<%= config.dist %>/libs/libs.min.js']


### PR DESCRIPTION
Added config option 'includeSourcemaps' which is set to false by default. This option removes all sourcemaps in your js production files by default. It does not remove your css sourcemaps during development!