### PR TITLE
Alias most important Grunt tasks to npm run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,20 @@
     "time-grunt": "1.4.0"
   },
   "scripts": {
-    "postinstall": "chmod u+x .postinstall.js && node ./.postinstall.js"
+    "postinstall": "chmod u+x .postinstall.js && node ./.postinstall.js",
+    "dev": "grunt dev",
+    "serve": "grunt serve",
+    "dev:watch": "grunt",
+    "dev:sync": "grunt sync",
+    "watch": "grunt watch",
+    "docs": "grunt jsdoc",
+    "lint": "grunt lint",
+    "lint:fix": "grunt lint:fix",
+    "build": "grunt build",
+    "build:check": "grunt build:check",
+    "release:patch": "grunt release:patch",
+    "release:minor": "grunt release:minor",
+    "release:major": "grunt release:major"
   },
   "bootstrapKickstart": {
     "bundleCSS": {},

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   },
   "scripts": {
     "postinstall": "chmod u+x .postinstall.js && node ./.postinstall.js",
+    "test": "grunt lint",
+    "start": "grunt sync",
     "dev": "grunt dev",
     "serve": "grunt serve",
     "dev:watch": "grunt",


### PR DESCRIPTION
I just mapped the most important Grunt tasks to npm run scripts. These are only the ones which are displayed via `grunt tasks`:

```
$ grunt tasks
Running "availabletasks:tasks" (availabletasks) task

Dev
default        =>  Default Task. Just type `grunt` for this one. Calls `grunt dev` first and `grunt server` afterwards.
dev            =>  `grunt dev` will lint your files, build sources within the assets directory and generating docs / reports.
sync           =>  `grunt sync` starts a local dev server, sync browsers and runs `grunt watch`
jsdoc          ->  `grunt jsdoc` generates source documentation using jsdoc.
serve          =>  `grunt serve` starts a local dev server and runs `grunt watch`
watch          >   `grunt watch` run dev tasks whenever watched files change and Reloads the browser with »LiveReload« plugin.
lint           =>  `grunt lint` lints JavaScript (ESLint) and HTML files (W3C validation and Bootlint)
lint:fix       =>  `grunt lint:fix` tries to fix your ESLint errors.

Production
build          =>  `grunt build` builds production ready sources to dist directory.
build:check    =>  `grunt build:check` starts a local server to make it possible to check the build in the browser.
release:patch  =>  `grunt release:patch` builds the current sources, bumps version number (0.0.1) and creates zip.files.
release:minor  =>  `grunt release:minor` builds the current sources, bumps version number (0.1.0) and creates zip.files.
release:major  =>  `grunt release:major` builds the current sources, bumps version number (1.0.0) and creates zip.files.

Done.
```

Please review carefully as we plan to keep the script names for 4.0.0 :neckbeard:

