### PR TITLE
Remove handlebars sources from build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,17 +362,6 @@ module.exports = function (grunt) {
 				expand: true,
 				src: staticFiles,
 				dest: '<%= config.server %>/'
-			},
-			handlebars: {
-				expand: true,
-				cwd: 'src',
-				src: [
-					'*.hbs',
-					'templates/*.hbs',
-					'partials/**/*.hbs',
-					'templates/helpers/helpers.js'
-				],
-				dest: '<%= config.dist %>/handlebarsSources'
 			}
 		},
 		jsdoc: {


### PR DESCRIPTION
@revrng I guess you are okay with not having this as default behavior.

Could be re-added on project base in case we would need it.
