### PR TITLE
Change handling of vendor files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,22 +20,10 @@ function getBundleCSSFiles(packageJson) {
 	}, []);
 }
 
-/*
- * Returns a list of all globs defined in the property `includeStaticFiles` of package.json
- * Used to copy files to development server and to the production build.
- */
-function getStaticFiles(packageJson) {
-	var basePath = 'node_modules/';
-	return packageJson.bootstrapKickstart.includeStaticFiles.map(function (glob) {
-		return basePath + glob;
-	});
-}
-
 module.exports = function (grunt) {
 	// Add frontend dependencies from package.json for adding its css files
 	var packageJson = grunt.file.readJSON('package.json');
 	var bundleCSSFiles = getBundleCSSFiles(packageJson);
-	var staticFiles = getStaticFiles(packageJson);
 
 	// Get devDependencies
 	getTasks(grunt, {
@@ -278,7 +266,7 @@ module.exports = function (grunt) {
 					keepSpecialComments: 0
 				},
 				files: {
-					'<%= config.dist %>/node_modules/libs.min.css': bundleCSSFiles
+					'<%= config.dist %>/libs/libs.min.css': bundleCSSFiles
 				}
 			},
 			npmLibsDevelopment: {
@@ -286,7 +274,7 @@ module.exports = function (grunt) {
 					keepSpecialComments: 0
 				},
 				files: {
-					'<%= config.server %>/node_modules/libs.min.css': bundleCSSFiles
+					'<%= config.server %>/libs/libs.min.css': bundleCSSFiles
 				}
 			}
 		},
@@ -344,8 +332,9 @@ module.exports = function (grunt) {
 			},
 			distFilesFromLibs: {
 				expand: true,
-				src: staticFiles,
-				dest: '<%= config.dist %>/'
+				cwd: 'node_modules',
+				src: packageJson.bootstrapKickstart.includeStaticFiles,
+				dest: '<%= config.dist %>/libs'
 			},
 			server: {
 				expand: true,
@@ -359,8 +348,9 @@ module.exports = function (grunt) {
 			},
 			serverFilesFromLibs: {
 				expand: true,
-				src: staticFiles,
-				dest: '<%= config.server %>/'
+				cwd: 'node_modules',
+				src: packageJson.bootstrapKickstart.includeStaticFiles,
+				dest: '<%= config.server %>/libs'
 			}
 		},
 		jsdoc: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,22 +132,20 @@ module.exports = function (grunt) {
 		uglify: {
 			options: {
 				banner: '<%= config.banner %>\n',
-				sourceMap: true,
-				sourceMapIncludeSources: true,
+				sourceMap: false,
 				compress: {
 					drop_console: false, // eslint-disable-line camelcase
 					drop_debugger: true // eslint-disable-line camelcase
 				}
 			},
-			browserifyOutput: {
-				options: {
-					sourceMap: false
-				},
+			client: {
 				files: {
-					'<%= config.dist %>/app/built.min.js': [
-						'<%= config.server %>/app/vendor.js',
-						'<%= config.server %>/app/client.js'
-					]
+					'<%= config.dist %>/app/client.min.js': ['<%= config.server %>/app/client.js']
+				}
+			},
+			vendor: {
+				files: {
+					'<%= config.dist %>/libs/vendor.min.js': ['<%= config.server %>/libs/vendor.js']
 				}
 			}
 		},
@@ -546,7 +544,7 @@ module.exports = function (grunt) {
 		browserify: {
 			vendor: {
 				src: [],
-				dest: '<%= config.server %>/app/vendor.js',
+				dest: '<%= config.server %>/libs/vendor.js',
 				options: {
 					require: packageJson.bootstrapKickstart.bundleExternalJS
 				}
@@ -713,7 +711,7 @@ module.exports = function (grunt) {
 			'browserify:vendor',
 			'browserify:clientProduction',
 			'copy',
-			'uglify:browserifyOutput',
+			'uglify',
 			'uncss',
 			'usebanner',
 			'clean:temp',

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This will give you the main Grunt tasks which are ready for you to be fired from
 ````
 Dev
 default        =>  Default Task. Just type `grunt` for this one. Calls `grunt dev` first and `grunt server` afterwards.
-dev            =>  `grunt dev` will lint your files, build sources within the assets directory and generating docs / reports.
+dev            =>  `grunt dev` will lint your files, build sources within the server directory.
 sync           =>  `grunt sync` starts a local dev server, sync browsers and runs `grunt watch`
 jsdoc          ->  `grunt jsdoc` generates source documentation using jsdoc.
 serve          =>  `grunt serve` starts a local dev server and runs `grunt watch`
@@ -127,30 +127,23 @@ release:patch  =>  `grunt release:patch` builds the current sources and bumps ve
 release:minor  =>  `grunt release:minor` builds the current sources and bumps version number (0.1.0).
 release:major  =>  `grunt release:major` builds the current sources and bumps version number (1.0.0).
 ````
-Running those tasks will create a bunch of directories and files which aren’t under version control. So don’t wonder when the following ressources are created after setting up the project:
+Running those tasks will create a bunch of directories and files which aren’t under version control. So don’t wonder when the following resources are created after setting up and working with the project:
 
 ````
-bootstrap-kickstart/
-├── assets/
-│   ├── css/
-│   │   ├── index.css          → Compiled and autoprefixed from LESS files
-│   │   └── index.css.map      → Sourcemap which maps to LESS files
-│   └── js/
-│       ├── file.min.js        → Minified JavaScript file
-│       └── file.min.js.map    → Sourcemap which maps to original js file
-├── dist/                      → Contains the files ready for production
-│   ├── assets/
-│   │   ├── css/
-│   │   │   ├── index.css      → Compiled and autoprefixed from LESS files
-│   │   │   └── index.css.map  → Sourcemap which maps to LESS files
-│   │   ├── fonts/             → Fonts copied from /assets/fonts
-│   │   ├── img/               → Optimized images from /assets/img
-│   │   └── js/
-│   │       └── file.min.js    → Minified JavaScript file (without console output)
-│   └── libs/                  → Relevant files copied from /libs
-├── docs/                      → JavaScript generated from DocBlock comments
+myProject
+├── dist                       → Contains the files ready for production
+│   ├── app
+│   ├── assets
+│   └── libs                   → Relevant files copied from /node_modules
+├── docs                       → JavaScript Docs generated from DocBlock comments
 ├── node_modules/              → Dependencies installed by npm
-└── server/                    → Contains files for running a local dev server
+├── server                     → Contains the files for the development server
+│   ├── app
+│   ├── assets
+│   └── libs                   → Relevant files copied from /node_modules
+└── src
+    └── assets
+        └── css                → Transpiled and autoprefixed from LESS files
 ````
 
 See `/Gruntfile.js` to see what happens in Details.
@@ -472,10 +465,22 @@ Finally add the library to the `bundleExternalJS` section of `package.json` to a
 ```
 bundleExternalJS": ["jquery", "bootstrap", "select2"]
 ```
+The bundled JavaScript is stored in the `libs` directory during the build process:
+
+```
+myProject
+├── server
+│   └── libs
+│       └── vendor.js
+└── dist
+    └── libs
+        └── vendor.min.js
+```
 
 ### Bundling CSS from dependencies
 
 If your lib ships its own CSS, create a property for your lib in the `bundleCSS` section of your `package.json` where the key is equivalent to the npm package name and the value a string array containing all paths to css files relative to its module folder.
+
 ```
 "bundleCSS": {
     "select2": [
@@ -485,6 +490,67 @@ If your lib ships its own CSS, create a property for your lib in the `bundleCSS`
       "select2-bootstrap.css"
     ]
   }
+```
+
+The bundled CSS is stored in the `libs` directory during the build process:
+
+```
+myProject
+├── server
+│   └── libs
+│       └── libs.css
+└── dist
+    └── libs
+        └── libs.min.css
+```
+
+### Including static files from dependencies
+
+Sometimes you need to copy static files from an npm package to your project. This may be fonts or JavaScript files you need to include via a seperate `<script>` tag.
+To handle that you just have to include the files in the `includeStaticFiles` section of your `package.json`. Please not that glob pattern macthing is supported over here.
+
+```
+"includeStaticFiles": [
+    "bootstrap/fonts/**/*",
+    "html5shiv/dist/html5shiv-printshiv.min.js",
+    "respond.js/dest/respond.min.js"
+]
+```
+
+These files are stored in the `libs` directory during the build process:
+
+```
+myProject
+├── server
+│   └── libs
+│       ├── bootstrap
+│       │   └── fonts
+│       │       ├── glyphicons-halflings-regular.eot
+│       │       ├── glyphicons-halflings-regular.svg
+│       │       ├── glyphicons-halflings-regular.ttf
+│       │       ├── glyphicons-halflings-regular.woff
+│       │       └── glyphicons-halflings-regular.woff2
+│       ├── html5shiv
+│       │   └── dist
+│       │       └── html5shiv-printshiv.min.js
+│       └── respond.js
+│           └── dest
+│               └── respond.min.js
+└── dist
+    └── libs
+        ├── bootstrap
+        │   └── fonts
+        │       ├── glyphicons-halflings-regular.eot
+        │       ├── glyphicons-halflings-regular.svg
+        │       ├── glyphicons-halflings-regular.ttf
+        │       ├── glyphicons-halflings-regular.woff
+        │       └── glyphicons-halflings-regular.woff2
+        ├── html5shiv
+        │   └── dist
+        │       └── html5shiv-printshiv.min.js
+        └── respond.js
+            └── dest
+                └── respond.min.js
 ```
 
 ### Changing versions of external resources

--- a/src/assets/less/index.less
+++ b/src/assets/less/index.less
@@ -3,7 +3,7 @@
 @import "../../../node_modules/bootstrap/less/bootstrap.less";
 
 // Set path to icon fonts
-@icon-font-path: "../../../node_modules/bootstrap/fonts/";
+@icon-font-path: "../../../libs/bootstrap/fonts/";
 /**
  * --------------------------------------------------
  * Here begins our own CSS in the rendered CSS file.

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -22,8 +22,8 @@
 	<!-- Libs -->
 	<!-- TODO: We need a way to integrate css-files from the libs with browserify -->
 
-	<!-- build:css:dist node_modules/libs.min.css -->
-	<link href="node_modules/libs.min.css" rel="stylesheet" />
+	<!-- build:css:dist libs/libs.min.css -->
+	<link href="libs/libs.min.css" rel="stylesheet" />
 	<!-- /build -->
 
 
@@ -35,8 +35,8 @@
 
 	<!-- HTML5 shim and Respond.js IE8 support for HTML5 elements and media queries. -->
 	<!--[if lt IE 9]>
-		<script src="node_modules/html5shiv/dist/html5shiv-printshiv.min.js"></script>
-		<script src="node_modules/respond.js/dest/respond.min.js"></script>
+		<script src="libs/html5shiv/dist/html5shiv-printshiv.min.js"></script>
+		<script src="libs/respond.js/dest/respond.min.js"></script>
 	<![endif]-->
 
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory. -->

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -65,11 +65,16 @@
 	replaced in the production ready build.
 	-->
 
+	<!-- Vendor JS -->
+	<!-- build:js:dist libs/vendor.min.js -->
+	<script src="libs/vendor.js"></script>
+	<!-- /build -->
+
 	<!-- Own JS -->
-	<!-- build:js:dist app/built.min.js -->
-	<script src="app/vendor.js"></script>
+	<!-- build:js:dist app/client.min.js -->
 	<script src="app/client.js"></script>
 	<!-- /build -->
+
 
 	<!-- External scripts (eg. analytics) should be placed here -->
 </body>


### PR DESCRIPTION
🔥 This is the last pull request before the release of 3.0.0 🔥 

---

Please leave a 👍 or a :shipit: if you want that to be merged as it is.

After talking about this with @krnlde and @revrng I implemented the following changes:

+ Rename `node_modules` to `libs` for dev and production build 
+ Store client.js and vendor.js in different directories
+ Replace built.min.js for production with seperated minified files:
  + `app/client.min.js`
  + `libs/vendor.min.js`
  + Result of a consideration between the amount of HTTP request against better caching.
+ Update docs regarding libs

## Before

<img width="1149" alt="before" src="https://cloud.githubusercontent.com/assets/441011/24429743/a91a4a8c-1413-11e7-9e8c-5d504e1a3939.png">

## After

<img width="1149" alt="after" src="https://cloud.githubusercontent.com/assets/441011/24429749/af0d043e-1413-11e7-954b-c36031ad491b.png">


