### PR TITLE
Export tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See: <https://github.com/micromata/generator-bootstrap-kickstart>
 	$ git clone https://github.com/micromata/bootstrap-kickstart.git
 	$ cd bootstrap-kickstart
 	$ npm install
-	$ grunt tasks
+	$ gulp --tasks
 
 ## Dependencies
 
@@ -101,33 +101,59 @@ and call:
 
 npm will look at the `package.json` file and automatically fetch and install the necessary local dependencies needed for our grunt workflow as well as the needed frontend dependencies to `\node_modules`.
 
-## Grunt Workflow and tasks
+## Gulp Workflow and tasks
 
 When completed the setup, you'll be able to run the various Grunt tasks provided from the command line.
 
 Just type the following to get an overview about the available Tasks:
 
-	grunt tasks
+	gulp --tasks
 
-This will give you the main Grunt tasks which are ready for you to be fired from the terminal (grouped into »Dev« and »Production« Tasks):
+This will give you the main Gulp tasks which are ready for you to be fired from the terminal.:
 
 ````
-Dev
-default        =>  Default Task. Just type `grunt` for this one. Calls `grunt dev` first and `grunt server` afterwards.
-dev            =>  `grunt dev` will lint your files, build sources within the server directory.
-sync           =>  `grunt sync` starts a local dev server, sync browsers and runs `grunt watch`
-jsdoc          ->  `grunt jsdoc` generates source documentation using jsdoc.
-serve          =>  `grunt serve` starts a local dev server and runs `grunt watch`
-watch          >   `grunt watch` run dev tasks whenever watched files change and Reloads the browser with »LiveReload« plugin.
-lint           =>  `grunt lint` lints JavaScript (ESLint) and HTML files (W3C validation and Bootlint)
-lint:fix       =>  `grunt lint:fix` tries to fix your ESLint errors.
-
-Production
-build          =>  `grunt build` builds production ready sources to dist directory.
-build:check    =>  `grunt build:check` starts a local server to make it possible to check the build in the browser.
-release:patch  =>  `grunt release:patch` builds the current sources and bumps version number (0.0.1).
-release:minor  =>  `grunt release:minor` builds the current sources and bumps version number (0.1.0).
-release:major  =>  `grunt release:major` builds the current sources and bumps version number (1.0.0).
+Tasks for ~/Documents/Projects/bootstrap-kickstart/gulpfile.babel.js
+├─┬ build      `gulp build` is the main build task
+│ │ -prod      … builds for production to `dist` directory.
+│ └─┬ <series>
+│   ├── clean
+│   └─┬ <parallel>
+│     ├── processHtml
+│     ├── lint
+│     ├── images
+│     ├── clientScripts
+│     ├── vendorScripts
+│     ├── styles
+│     ├── bundleExternalCSS
+│     ├── copyStaticFiles
+│     ├── lintBootstrap
+│     ├── security
+│     └── test
+├─┬ default    `gulp` will build, serve, watch for changes and reload server
+│ └─┬ <series>
+│   ├─┬ <series>
+│   │ ├── clean
+│   │ └─┬ <parallel>
+│   │   ├── processHtml
+│   │   ├── lint
+│   │   ├── images
+│   │   ├── clientScripts
+│   │   ├── vendorScripts
+│   │   ├── styles
+│   │   ├── bundleExternalCSS
+│   │   ├── copyStaticFiles
+│   │   ├── lintBootstrap
+│   │   ├── security
+│   │   └── test
+│   ├── serve
+│   └── watch
+├── lint
+├── serve      `gulp serve` serves the build (`server` directory)
+│   -prod      … serves production build (`dist` directory)
+├── test       `gulp test` runs unit test via Jest CLI
+│   -prod      … exits with exit code 1 when tests are failing
+├── testWatch  `gulp testWatch` runs unit test with Jests native watch option
+└── watch      `gulp watch` watches for changes and runs tasks automatically
 ````
 Running those tasks will create a bunch of directories and files which aren’t under version control. So don’t wonder when the following resources are created after setting up and working with the project:
 
@@ -148,7 +174,7 @@ myProject
         └── css                → Transpiled and autoprefixed from LESS files
 ````
 
-See `/Gruntfile.js` to see what happens in Details.
+See `/gulpfile.babel.js` to see what happens in Details.
 
 ### Setting up your Editor (optional)
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -160,6 +160,7 @@ export function lint() {
 		.pipe(eslint.failAfterError())
 		.on('error', onError);
 }
+lint.description = '`gulp lint` lints JavaScript via ESLint';
 
 function security(done) {
 	if (isProdBuild()) {
@@ -198,11 +199,16 @@ export function test(done) {
 		done();
 	});
 }
+test.description = '`gulp test` runs unit test via Jest CLI';
+test.flags = {
+	'-prod': ' exits with exit code 1 when tests are failing'
+};
 
 export function testWatch(done) {
 	jest.runCLI({watch: true, config: pkgJson.jest}, '.', () => {});
 	done();
 }
+testWatch.description = '`gulp testWatch` runs unit test with Jests native watch option';
 
 export function serve(done) {
 	let baseDir = mainDirectories.dev;
@@ -216,6 +222,10 @@ export function serve(done) {
 	});
 	done();
 }
+serve.description = '`gulp serve` serves the build (`server` directory)';
+serve.flags = {
+	'-prod': ' serves production build (`dist` directory)'
+};
 
 function reload(done) {
 	server.reload();
@@ -228,11 +238,17 @@ export function watch() {
 	gulp.watch(settings.sources.styles, gulp.series(styles, reload));
 	gulp.watch(settings.sources.markup, gulp.parallel(lintBootstrap, gulp.series(processHtml, reload)));
 }
+watch.description = '`gulp watch` watches for changes and runs tasks automatically';
 
 export const build = gulp.series(
 	clean,
 	gulp.parallel(processHtml, lint, images, clientScripts, vendorScripts, styles, bundleExternalCSS, copyStaticFiles, lintBootstrap, security, test)
 );
+build.description = '`gulp build` is the main build task';
+build.flags = {
+	'-prod': ' builds for production to `dist` directory.'
+};
 
 const dev = gulp.series(build, serve, watch);
+dev.description = '`gulp` will build, serve, watch for changes and reload server';
 export default dev;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -42,14 +42,14 @@ function onError(err) {
 	this.emit('end');
 }
 
-export function clean() {
+function clean() {
 	if (isProdBuild()) {
 		return del(mainDirectories.dist);
 	}
 	return del(mainDirectories.dev);
 }
 
-export function styles() {
+function styles() {
 	if (isProdBuild()) {
 		return gulp.src(settings.sources.stylesEntryPoint)
 			.pipe(plumber({errorHandler: onError}))
@@ -78,7 +78,7 @@ export function styles() {
 		.pipe(gulp.dest(settings.destinations.dev.styles));
 }
 
-export function images() {
+function images() {
 	if (isProdBuild()) {
 		return gulp.src(settings.sources.images)
 			.pipe(imagemin())
@@ -88,7 +88,7 @@ export function images() {
 		.pipe(gulp.dest(settings.destinations.dev.images));
 }
 
-export function clientScripts() {
+function clientScripts() {
 	const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
 		.transform(babelify, {sourceMaps: true})
 		.external(settings.sources.externalJs);
@@ -109,7 +109,7 @@ export function clientScripts() {
 		.pipe(gulp.dest(settings.destinations.dev.scripts));
 }
 
-export function vendorScripts() {
+function vendorScripts() {
 	const b = browserify({...browserifyInc.args});
 	settings.sources.externalJs.forEach(dep => b.require(dep));
 	browserifyInc(b, {cacheFile: './.browserify-cache-vendor.json'});
@@ -127,7 +127,7 @@ export function vendorScripts() {
 		.pipe(gulp.dest(settings.destinations.dev.libs));
 }
 
-export function bundleExternalCSS(done) {
+function bundleExternalCSS(done) {
 	const files = pkgJson.bootstrapKickstart.bundleCSS.map(sourcePath => path.join('node_modules/', sourcePath));
 	if (!files.length) return done();
 	if (isProdBuild()) {
@@ -142,7 +142,7 @@ export function bundleExternalCSS(done) {
 		.pipe(gulp.dest(settings.destinations.dev.libs));
 }
 
-export function copyStaticFiles() {
+function copyStaticFiles() {
 	return gulp.src(settings.sources.staticFiles.map(sourcePath => path.join('node_modules/', sourcePath)), {base: 'node_modules/'})
 		.pipe(gulp.dest(isProdBuild() ? settings.destinations.prod.libs : settings.destinations.dev.libs));
 }
@@ -161,7 +161,7 @@ export function lint() {
 		.on('error', onError);
 }
 
-export function security(done) {
+function security(done) {
 	if (isProdBuild()) {
 		nsp({package: path.join(__dirname, '/package.json')}, done);
 	} else {
@@ -169,7 +169,7 @@ export function security(done) {
 	}
 }
 
-export function processHtml() {
+function processHtml() {
 	if (isProdBuild()) {
 		return gulp.src(settings.sources.markup)
 			.pipe(processhtml())
@@ -181,7 +181,7 @@ export function processHtml() {
 		.pipe(gulp.dest(settings.destinations.dev.markup));
 }
 
-export function lintBootstrap() {
+function lintBootstrap() {
 	return gulp.src(settings.sources.markup)
 		.pipe(bootlint({
 			stoponerror: isProdBuild(),


### PR DESCRIPTION
This PR will:
- Limit exports to make only the main tasks available as public gulp tasks.
  - these are the ones which are aliased as npm scripts
- Add metadata to tasks
  - useful for listing tasks via `gulp --tasks`
- Add comments to gulpfile
- Update README regarding listing the available tasks

Adding task metadata and limit exports leads to a pretty useful output of `gulp --tasks`:
![image](https://cloud.githubusercontent.com/assets/441011/25434624/4b781f4a-2a8d-11e7-84a0-7c49ab305129.png)
