### PR TITLE
Change and apply ESLint rule `arrow-parens`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "no-eq-null": ["off"],
     "quote-props": ["error", "as-needed"],
     "capitalized-comments": ["warn"],
-    "curly": ["error", "multi-line"]
+    "curly": ["error", "multi-line"],
+    "arrow-parens": ["off"]
   }
 }


### PR DESCRIPTION
Changed to:
```
"arrow-parens": ["error", "always"]
```
which is the ESLint default.

It was set to `[„error", "as-needed“]` which means that you have to remove parentheses around single function arguments. See diff.

This came from Sindres xo defaults.

It always bugged me. Then @krnlde came over and said that it is bugging him as well. 

We both agree, that it having parens around single arguments increases readability and makes it easier to adapth changes (add arguments).

Does everybody agree?