### PR TITLE
refactor(gulp): Split up gulpfile to different files

### DIFF
--- a/gulp/commandLineArgs.js
+++ b/gulp/commandLineArgs.js
@@ -1,0 +1,17 @@
+import minimist from 'minimist';
+
+export const args = minimist(process.argv.slice(2), {
+	boolean: ['production', 'watch'],
+	string: 'bump',
+	alias: {P: 'production', B: 'bump', W: 'watch'}
+});
+
+export function hasBumpType() {
+	return args.bump === 'major' ||
+					args.bump === 'minor' ||
+					args.bump === 'patch';
+}
+
+export function isProdBuild() {
+	return args.production || hasBumpType();
+}

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,4 +1,4 @@
-export const pkgJson = require('./package.json');
+export const pkgJson = require('../package.json');
 
 export const mainDirectories = {
 	dev: './server/',
@@ -35,15 +35,5 @@ export const settings = {
 			images: `${mainDirectories.dist}assets/img/`,
 			libs: `${mainDirectories.dist}libs/`
 		}
-	},
-	autoPrefix: {
-		browsers: [
-			'> 1%',
-			'last 3 version',
-			'ie 8',
-			'ie 9',
-			'Firefox ESR',
-			'Opera 12.1'
-		]
 	}
 };

--- a/gulp/onError.js
+++ b/gulp/onError.js
@@ -1,0 +1,19 @@
+import notify from 'gulp-notify';
+
+/**
+ * Configure notify error reporting.
+ * Can be used in tasks.
+ */
+function onError(err) {
+	notify({
+		title: 'Gulp Task Error',
+		subtitle: 'Plugin: <%= error.plugin %>',
+		message: 'Check the console.'
+	}).write(err);
+
+	console.error(err.toString());
+
+	this.emit('end');
+}
+
+export default onError;

--- a/gulp/tasks/appTemplates.js
+++ b/gulp/tasks/appTemplates.js
@@ -1,0 +1,21 @@
+import gulp from 'gulp';
+import changed from 'gulp-changed';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Copy HTML files from src/app/
+ */
+function appTemplates() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.appTemplates)
+			.pipe(changed(settings.destinations.prod.app))
+			.pipe(gulp.dest(settings.destinations.prod.app));
+	}
+	return gulp.src(settings.sources.appTemplates)
+		.pipe(changed(settings.destinations.dev.app))
+		.pipe(gulp.dest(settings.destinations.dev.app));
+}
+
+export default appTemplates;

--- a/gulp/tasks/bumpVersion.js
+++ b/gulp/tasks/bumpVersion.js
@@ -1,0 +1,29 @@
+import gulp from 'gulp';
+import chalk from 'chalk';
+import touch from 'gulp-touch';
+import bump from 'gulp-bump';
+import semver from 'semver';
+
+import {pkgJson} from '../config';
+import onError from '../onError';
+import {args, hasBumpType} from '../commandLineArgs';
+
+/**
+ * Bumps version in package.json.
+ * Used in release task.
+ */
+function bumpVersion() {
+	if (!hasBumpType()) {
+		onError(new Error(chalk.red('Please specify release type: gulp release --bump (major|minor|patch)')));
+	}
+
+	pkgJson.version = semver.inc(pkgJson.version, args.bump);
+
+	return gulp.src('./package.json')
+		.pipe(bump({type: args.bump}))
+		.on('error', onError)
+		.pipe(gulp.dest('./'))
+		.pipe(touch());
+}
+
+export default bumpVersion;

--- a/gulp/tasks/bundleExternalCSS.js
+++ b/gulp/tasks/bundleExternalCSS.js
@@ -1,0 +1,27 @@
+import path from 'path';
+import gulp from 'gulp';
+import cleanCss from 'gulp-clean-css';
+import concat from 'gulp-concat';
+
+import {settings, pkgJson} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Bundle CSS files defined in package.json → bootstrapKickstart.bundleCSS
+ */
+function bundleExternalCSS(done) {
+	const files = pkgJson.bootstrapKickstart.bundleCSS.map(sourcePath => path.join('node_modules/', sourcePath));
+	if (!files.length) return done();
+	if (isProdBuild()) {
+
+		return gulp.src(files)
+			.pipe(cleanCss())
+			.pipe(concat('libs.min.css'))
+			.pipe(gulp.dest(settings.destinations.prod.libs));
+	}
+	return gulp.src(files)
+		.pipe(concat('libs.css'))
+		.pipe(gulp.dest(settings.destinations.dev.libs));
+}
+
+export default bundleExternalCSS;

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,0 +1,16 @@
+import del from 'del';
+
+import {mainDirectories} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Delete output directories
+ */
+function clean() {
+	if (isProdBuild()) {
+		return del(mainDirectories.dist);
+	}
+	return del(mainDirectories.dev);
+}
+
+export default clean;

--- a/gulp/tasks/clientScripts.js
+++ b/gulp/tasks/clientScripts.js
@@ -1,0 +1,43 @@
+import gulp from 'gulp';
+import browserify from 'browserify';
+import browserifyInc from 'browserify-incremental';
+import babelify from 'babelify';
+import buffer from 'vinyl-buffer';
+import source from 'vinyl-source-stream';
+import rename from 'gulp-rename';
+import uglify from 'gulp-uglify';
+
+import {settings} from '../config';
+import onError from '../onError';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Bundle own JavaScript excluding libs defined in package.json → bootstrapKickstart.bundleExternalJS
+ */
+function clientScripts() {
+	const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
+		.transform(babelify, {sourceMaps: true})
+		.external(settings.sources.externalJs);
+	browserifyInc(b, {cacheFile: './.browserify-cache-client.json'});
+
+	if (isProdBuild()) {
+		return b.bundle()
+			.pipe(source('client.js'))
+			.pipe(buffer())
+			.pipe(rename('client.min.js'))
+			.pipe(uglify({
+				compress: {
+					drop_console: true, // eslint-disable-line camelcase
+					drop_debugger: true // eslint-disable-line camelcase
+				}
+			}))
+			.pipe(gulp.dest(settings.destinations.prod.app));
+	}
+	return b.bundle()
+		.on('error', onError)
+		.pipe(source('client.js'))
+		.pipe(buffer())
+		.pipe(gulp.dest(settings.destinations.dev.app));
+}
+
+export default clientScripts;

--- a/gulp/tasks/clientScripts.js
+++ b/gulp/tasks/clientScripts.js
@@ -11,14 +11,15 @@ import {settings} from '../config';
 import onError from '../onError';
 import {isProdBuild} from '../commandLineArgs';
 
+const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
+	.transform(babelify, {sourceMaps: true})
+	.external(settings.sources.externalJs);
+browserifyInc(b, {cacheFile: './.browserify-cache-client.json'});
+
 /**
  * Bundle own JavaScript excluding libs defined in package.json → bootstrapKickstart.bundleExternalJS
  */
 function clientScripts() {
-	const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
-		.transform(babelify, {sourceMaps: true})
-		.external(settings.sources.externalJs);
-	browserifyInc(b, {cacheFile: './.browserify-cache-client.json'});
 
 	if (isProdBuild()) {
 		return b.bundle()

--- a/gulp/tasks/commitChanges.js
+++ b/gulp/tasks/commitChanges.js
@@ -1,0 +1,16 @@
+import gulp from 'gulp';
+import git from 'gulp-git';
+
+import {pkgJson} from '../config';
+
+/**
+ * Commits changes.
+ * Used in release task.
+ */
+function commitChanges() {
+	return gulp.src('.')
+		.pipe(git.add())
+		.pipe(git.commit(`Release ${pkgJson.version}`));
+}
+
+export default commitChanges;

--- a/gulp/tasks/copyStaticFiles.js
+++ b/gulp/tasks/copyStaticFiles.js
@@ -1,0 +1,15 @@
+import gulp from 'gulp';
+import path from 'path';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Copy files defined in package.json → bootstrapKickstart.includeStaticFiles
+ */
+function copyStaticFiles() {
+	return gulp.src(settings.sources.staticFiles.map(sourcePath => path.join('node_modules/', sourcePath)), {base: 'node_modules/'})
+		.pipe(gulp.dest(isProdBuild() ? settings.destinations.prod.libs : settings.destinations.dev.libs));
+}
+
+export default copyStaticFiles;

--- a/gulp/tasks/createChangelog.js
+++ b/gulp/tasks/createChangelog.js
@@ -1,0 +1,13 @@
+import gulp from 'gulp';
+import changelog from 'gulp-conventional-changelog';
+/**
+ * Creates changelog.
+ * Used in release task.
+ */
+function createChangelog() {
+	return gulp.src('./CHANGELOG.md', {buffer: false})
+		.pipe(changelog({preset: 'angular'}))
+		.pipe(gulp.dest('./'));
+}
+
+export default createChangelog;

--- a/gulp/tasks/createTag.js
+++ b/gulp/tasks/createTag.js
@@ -1,0 +1,17 @@
+import git from 'gulp-git';
+
+import {pkgJson} from '../config';
+import onError from '../onError';
+
+/**
+ * Creates Git tag.
+ * Used in release task.
+ */
+function createTag(done) {
+	git.tag(pkgJson.version, `Created tag for version: ${pkgJson.version}`, error => {
+		if (error) return onError(error);
+		done();
+	});
+}
+
+export default createTag;

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -1,0 +1,21 @@
+import gulp from 'gulp';
+import changed from 'gulp-changed';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Copy fonts from src/assets/fonts
+ */
+function fonts() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.fonts)
+			.pipe(changed(settings.destinations.prod.fonts))
+			.pipe(gulp.dest(settings.destinations.prod.fonts));
+	}
+	return gulp.src(settings.sources.fonts)
+		.pipe(changed(settings.destinations.dev.fonts))
+		.pipe(gulp.dest(settings.destinations.dev.fonts));
+}
+
+export default fonts;

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,0 +1,20 @@
+import gulp from 'gulp';
+import imagemin from 'gulp-imagemin';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Minify PNG, JPEG, GIF and SVG images with imagemin
+ */
+function images() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.images)
+			.pipe(imagemin())
+			.pipe(gulp.dest(settings.destinations.prod.images));
+	}
+	return gulp.src(settings.sources.images)
+		.pipe(gulp.dest(settings.destinations.dev.images));
+}
+
+export default images;

--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -1,0 +1,31 @@
+import gulp from 'gulp';
+import eslint from 'gulp-eslint';
+
+import {settings} from '../config';
+import onError from '../onError';
+import {isProdBuild} from '../commandLineArgs';
+/**
+ * ESLint task:
+ * Run `gulp lint` respectively `gulp lint --production`
+ */
+function lint() {
+	if (isProdBuild()) {
+		return gulp.src([...settings.sources.scripts, './*.js'])
+			.pipe(eslint())
+			.pipe(eslint.format())
+			.pipe(eslint.failAfterError());
+	}
+	/**
+	 * TODO: Run ESLint with --fix for dev build
+	 * Seems that isn’t possible to fix files in place with multiple inputs. See example.
+	 * Looks like we would need to use https://github.com/robrich/gulp-exec to execute ESLint (or xo) with the fix option.
+	 */
+	return gulp.src([...settings.sources.scripts, './*.js'])
+		.pipe(eslint())
+		.pipe(eslint.format())
+		.pipe(eslint.failAfterError())
+		.on('error', onError);
+}
+lint.description = '`gulp lint` lints JavaScript via ESLint';
+
+export default lint;

--- a/gulp/tasks/lintBootstrap.js
+++ b/gulp/tasks/lintBootstrap.js
@@ -1,0 +1,18 @@
+import gulp from 'gulp';
+import bootlint from 'gulp-bootlint';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Lint HTML with Bootlint
+ */
+function lintBootstrap() {
+	return gulp.src(settings.sources.markup)
+		.pipe(bootlint({
+			stoponerror: isProdBuild(),
+			disabledIds: ['W005']
+		}));
+}
+
+export default lintBootstrap;

--- a/gulp/tasks/processHtml.js
+++ b/gulp/tasks/processHtml.js
@@ -1,0 +1,27 @@
+import gulp from 'gulp';
+import changed from 'gulp-changed';
+import htmlmin from 'gulp-htmlmin';
+import processhtml from 'gulp-processhtml';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Process HTML:
+ * - Replaces references to JS and CSS for production build
+ * - Remove comments for production build
+ * - Simply copy HTML for dev build
+ */
+function processHtml() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.markup)
+			.pipe(processhtml())
+			.pipe(htmlmin({removeComments: true, preserveLineBreaks: true, collapseWhitespace: true}))
+			.pipe(gulp.dest(settings.destinations.prod.markup));
+	}
+	return gulp.src(settings.sources.markup)
+		.pipe(changed(settings.destinations.dev.markup))
+		.pipe(gulp.dest(settings.destinations.dev.markup));
+}
+
+export default processHtml;

--- a/gulp/tasks/security.js
+++ b/gulp/tasks/security.js
@@ -1,0 +1,17 @@
+import nsp from 'gulp-nsp';
+import path from 'path';
+
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Check dependencies with help of the node security platform
+ */
+function security(done) {
+	if (isProdBuild()) {
+		nsp({package: path.join(__dirname, '../../package.json')}, done);
+	} else {
+		done();
+	}
+}
+
+export default security;

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -1,0 +1,34 @@
+import browserSync from 'browser-sync';
+
+import {mainDirectories} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+
+const server = browserSync.create();
+
+/**
+ * Serve task:
+ * Run `gulp serve` respectively `gulp serve --production`
+ */
+export function serve(done) {
+	let baseDir = mainDirectories.dev;
+	if (isProdBuild()) {
+		baseDir = mainDirectories.dist;
+	}
+	server.init({
+		server: {
+			baseDir
+		}
+	});
+	done();
+}
+serve.description = '`gulp serve` serves the build (`server` directory)';
+serve.flags = {
+	'--production': ' serves production build (`dist` directory)',
+	'-P': ' Alias for --production'
+};
+
+//  Helper function to reload server
+export function reload(done) {
+	server.reload();
+	done();
+}

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,0 +1,57 @@
+import gulp from 'gulp';
+import plumber from 'gulp-plumber';
+import less from 'gulp-less';
+import sourcemaps from 'gulp-sourcemaps';
+import uncss from 'gulp-uncss';
+import Autoprefix from 'less-plugin-autoprefix';
+import cleanCss from 'gulp-clean-css';
+import rename from 'gulp-rename';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+import onError from '../onError';
+
+const autoPrefixOptions = {
+	browsers: [
+		'> 1%',
+		'last 3 version',
+		'ie 8',
+		'ie 9',
+		'Firefox ESR',
+		'Opera 12.1'
+	]
+};
+
+/**
+ * Handles LESS transpiling, auto prefixing, minifying and UnCSS.
+ */
+function styles() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.stylesEntryPoint)
+			.pipe(plumber({errorHandler: onError}))
+			.pipe(less({
+				plugins: [new Autoprefix(autoPrefixOptions)]
+			}))
+			.pipe(cleanCss())
+			.pipe(rename({
+				baseName: 'index',
+				suffix: '.min'
+			}))
+			.pipe(gulp.dest(settings.destinations.prod.styles))
+			.pipe(rename('index.uncss.min.css'))
+			.pipe(uncss({
+				html: settings.sources.markup
+			}))
+			.pipe(gulp.dest(settings.destinations.prod.styles));
+	}
+	return gulp.src(settings.sources.stylesEntryPoint)
+		.pipe(plumber({errorHandler: onError}))
+		.pipe(sourcemaps.init())
+		.pipe(less({
+			plugins: [new Autoprefix(autoPrefixOptions)]
+		}))
+		.pipe(sourcemaps.write('./'))
+		.pipe(gulp.dest(settings.destinations.dev.styles));
+}
+
+export default styles;

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,0 +1,33 @@
+import jest from 'jest-cli';
+
+import {pkgJson} from '../config';
+import {args, isProdBuild} from '../commandLineArgs';
+
+/**
+ * Test task:
+ * Run `gulp test`, `gulp test --watch` or `gulp test --production` in CI to
+ * make exit with a correct exit code when tests are failing
+ */
+function test(done) {
+	if (args.watch) {
+		jest.runCLI({watch: true, config: pkgJson.jest}, '.', () => {});
+		done();
+	}
+
+	jest.runCLI({config: pkgJson.jest}, '.', result => {
+		if (isProdBuild() && !result.success) {
+			done();
+			process.exit(1);
+		}
+		done();
+	});
+}
+test.description = '`gulp test` runs unit test via Jest CLI';
+test.flags = {
+	'--production': ' exits with exit code 1 when tests are failing (CI)',
+	'-P': ' Alias for --production',
+	'--watch': ' runs unit test with Jests native watch option',
+	'-W': ' Alias for --watch'
+};
+
+export default test;

--- a/gulp/tasks/validateHtml.js
+++ b/gulp/tasks/validateHtml.js
@@ -1,0 +1,23 @@
+import gulp from 'gulp';
+import htmllint from 'gulp-html';
+
+import {settings} from '../config';
+import {isProdBuild} from '../commandLineArgs';
+import onError from '../onError';
+
+/**
+ * HTML validation using the Nu HTML Checker
+ */
+function validateHtml() {
+	if (isProdBuild()) {
+		return gulp.src(settings.sources.markup)
+			.pipe(htmllint())
+			.pipe(gulp.dest(settings.destinations.dev.markup));
+	}
+	return gulp.src(settings.sources.markup)
+		.pipe(htmllint())
+		.on('error', onError)
+		.pipe(gulp.dest(settings.destinations.prod.markup));
+}
+
+export default validateHtml;

--- a/gulp/tasks/vendorScripts.js
+++ b/gulp/tasks/vendorScripts.js
@@ -1,0 +1,36 @@
+import gulp from 'gulp';
+import browserify from 'browserify';
+import browserifyInc from 'browserify-incremental';
+import buffer from 'vinyl-buffer';
+import source from 'vinyl-source-stream';
+import uglify from 'gulp-uglify';
+import envify from 'gulp-envify';
+
+import {settings} from '../config';
+import onError from '../onError';
+import {isProdBuild} from '../commandLineArgs';
+
+/**
+ * Bundle JavaScript libs defined in package.json → bootstrapKickstart.bundleExternalJS
+ */
+function vendorScripts() {
+	const b = browserify({...browserifyInc.args});
+	settings.sources.externalJs.forEach(dep => b.require(dep));
+	browserifyInc(b, {cacheFile: './.browserify-cache-vendor.json'});
+
+	if (isProdBuild()) {
+		return b.bundle()
+			.pipe(source('vendor.min.js'))
+			.pipe(buffer())
+			.pipe(envify({NODE_ENV: 'production'}))
+			.pipe(uglify())
+			.pipe(gulp.dest(settings.destinations.prod.libs));
+	}
+	return b.bundle()
+		.on('error', onError)
+		.pipe(source('vendor.js'))
+		.pipe(buffer())
+		.pipe(gulp.dest(settings.destinations.dev.libs));
+}
+
+export default vendorScripts;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,369 +1,47 @@
-import path from 'path';
-import del from 'del';
+// Import npm modules
 import chalk from 'chalk';
-import browserSync from 'browser-sync';
-import browserify from 'browserify';
-import browserifyInc from 'browserify-incremental';
-import babelify from 'babelify';
-import Autoprefix from 'less-plugin-autoprefix';
-import jest from 'jest-cli';
-import buffer from 'vinyl-buffer';
-import source from 'vinyl-source-stream';
-import touch from 'gulp-touch';
 import gulp from 'gulp';
-import bootlint from 'gulp-bootlint';
-import changed from 'gulp-changed';
-import cleanCss from 'gulp-clean-css';
-import concat from 'gulp-concat';
-import eslint from 'gulp-eslint';
-import htmlmin from 'gulp-htmlmin';
-import imagemin from 'gulp-imagemin';
-import less from 'gulp-less';
-import notify from 'gulp-notify';
-import nsp from 'gulp-nsp';
-import plumber from 'gulp-plumber';
-import processhtml from 'gulp-processhtml';
-import sourcemaps from 'gulp-sourcemaps';
-import uglify from 'gulp-uglify';
-import uncss from 'gulp-uncss';
 import gutil from 'gulp-util';
-import rename from 'gulp-rename';
-import bump from 'gulp-bump';
-import changelog from 'gulp-conventional-changelog';
-import git from 'gulp-git';
-import minimist from 'minimist';
-import semver from 'semver';
-import envify from 'gulp-envify';
-import htmllint from 'gulp-html';
-import {settings, mainDirectories, pkgJson} from './gulp.config';
 
-const server = browserSync.create();
-const args = minimist(process.argv.slice(2), {
-	boolean: ['production', 'watch'],
-	string: 'bump',
-	alias: {P: 'production', B: 'bump', W: 'watch'}
-});
+// Import settings
+import {settings} from './gulp/config';
 
-function hasBumpType() {
-	return args.bump === 'major' ||
-					args.bump === 'minor' ||
-					args.bump === 'patch';
-}
-
-function isProdBuild() {
-	return args.production || hasBumpType();
-}
-
-/**
- * Configure notify error reporting.
- * Can be used in tasks.
- */
-function onError(err) {
-	notify({
-		title: 'Gulp Task Error',
-		subtitle: 'Plugin: <%= error.plugin %>',
-		message: 'Check the console.'
-	}).write(err);
-
-	console.error(err.toString());
-
-	this.emit('end');
-}
+// Import tasks
+import clean from './gulp/tasks/clean';
+import styles from './gulp/tasks/styles';
+import fonts from './gulp/tasks/fonts';
+import images from './gulp/tasks/images';
+import appTemplates from './gulp/tasks/appTemplates';
+import clientScripts from './gulp/tasks/clientScripts';
+import vendorScripts from './gulp/tasks/vendorScripts';
+import bundleExternalCSS from './gulp/tasks/bundleExternalCSS';
+import copyStaticFiles from './gulp/tasks/copyStaticFiles';
+import lint from './gulp/tasks/lint';
+import security from './gulp/tasks/security';
+import processHtml from './gulp/tasks/processHtml';
+import lintBootstrap from './gulp/tasks/lintBootstrap';
+import test from './gulp/tasks/test';
+import {serve, reload} from './gulp/tasks/serve';
+import bumpVersion from './gulp/tasks/bumpVersion';
+import createChangelog from './gulp/tasks/createChangelog';
+import commitChanges from './gulp/tasks/commitChanges';
+import createTag from './gulp/tasks/createTag';
+import validateHtml from './gulp/tasks/validateHtml';
 
 /**
- * Delete output directories
- */
-function clean() {
-	if (isProdBuild()) {
-		return del(mainDirectories.dist);
-	}
-	return del(mainDirectories.dev);
-}
-
-/**
- * Handles LESS transpiling, auto prefixing, minifying and UnCSS.
- */
-function styles() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.stylesEntryPoint)
-			.pipe(plumber({errorHandler: onError}))
-			.pipe(less({
-				plugins: [new Autoprefix(settings.autoPrefix)]
-			}))
-			.pipe(cleanCss())
-			.pipe(rename({
-				baseName: 'index',
-				suffix: '.min'
-			}))
-			.pipe(gulp.dest(settings.destinations.prod.styles))
-			.pipe(rename('index.uncss.min.css'))
-			.pipe(uncss({
-				html: settings.sources.markup
-			}))
-			.pipe(gulp.dest(settings.destinations.prod.styles));
-	}
-	return gulp.src(settings.sources.stylesEntryPoint)
-		.pipe(plumber({errorHandler: onError}))
-		.pipe(sourcemaps.init())
-		.pipe(less({
-			plugins: [new Autoprefix(settings.autoPrefix)]
-		}))
-		.pipe(sourcemaps.write('./'))
-		.pipe(gulp.dest(settings.destinations.dev.styles));
-}
-
-/**
- * Copy fonts from src/assets/fonts
- */
-function fonts() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.fonts)
-			.pipe(changed(settings.destinations.prod.fonts))
-			.pipe(gulp.dest(settings.destinations.prod.fonts));
-	}
-	return gulp.src(settings.sources.fonts)
-		.pipe(changed(settings.destinations.dev.fonts))
-		.pipe(gulp.dest(settings.destinations.dev.fonts));
-}
-
-/**
- * Minify PNG, JPEG, GIF and SVG images with imagemin
- */
-function images() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.images)
-			.pipe(imagemin())
-			.pipe(gulp.dest(settings.destinations.prod.images));
-	}
-	return gulp.src(settings.sources.images)
-		.pipe(gulp.dest(settings.destinations.dev.images));
-}
-
-function appTemplates() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.appTemplates)
-			.pipe(changed(settings.destinations.prod.app))
-			.pipe(gulp.dest(settings.destinations.prod.app));
-	}
-	return gulp.src(settings.sources.appTemplates)
-		.pipe(changed(settings.destinations.dev.app))
-		.pipe(gulp.dest(settings.destinations.dev.app));
-}
-
-/**
- * Bundle own JavaScript excluding libs defined in package.json → bootstrapKickstart.bundleExternalJS
- */
-function clientScripts() {
-	const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
-		.transform(babelify, {sourceMaps: true})
-		.external(settings.sources.externalJs);
-	browserifyInc(b, {cacheFile: './.browserify-cache-client.json'});
-
-	if (isProdBuild()) {
-		return b.bundle()
-			.pipe(source('client.js'))
-			.pipe(buffer())
-			.pipe(rename('client.min.js'))
-			.pipe(uglify({
-				compress: {
-					drop_console: true, // eslint-disable-line camelcase
-					drop_debugger: true // eslint-disable-line camelcase
-				}
-			}))
-			.pipe(gulp.dest(settings.destinations.prod.app));
-	}
-	return b.bundle()
-		.on('error', onError)
-		.pipe(source('client.js'))
-		.pipe(buffer())
-		.pipe(gulp.dest(settings.destinations.dev.app));
-}
-
-/**
- * Bundle JavaScript libs defined in package.json → bootstrapKickstart.bundleExternalJS
- */
-function vendorScripts() {
-	const b = browserify({...browserifyInc.args});
-	settings.sources.externalJs.forEach(dep => b.require(dep));
-	browserifyInc(b, {cacheFile: './.browserify-cache-vendor.json'});
-
-	if (isProdBuild()) {
-		return b.bundle()
-			.pipe(source('vendor.min.js'))
-			.pipe(buffer())
-			.pipe(envify({NODE_ENV: 'production'}))
-			.pipe(uglify())
-			.pipe(gulp.dest(settings.destinations.prod.libs));
-	}
-	return b.bundle()
-		.pipe(source('vendor.js'))
-		.pipe(buffer())
-		.pipe(gulp.dest(settings.destinations.dev.libs));
-}
-
-/**
- * Bundle CSS files defined in package.json → bootstrapKickstart.bundleCSS
- */
-function bundleExternalCSS(done) {
-	const files = pkgJson.bootstrapKickstart.bundleCSS.map(sourcePath => path.join('node_modules/', sourcePath));
-	if (!files.length) return done();
-	if (isProdBuild()) {
-
-		return gulp.src(files)
-			.pipe(cleanCss())
-			.pipe(concat('libs.min.css'))
-			.pipe(gulp.dest(settings.destinations.prod.libs));
-	}
-	return gulp.src(files)
-		.pipe(concat('libs.css'))
-		.pipe(gulp.dest(settings.destinations.dev.libs));
-}
-
-/**
- * Copy files defined in package.json → bootstrapKickstart.includeStaticFiles
- */
-function copyStaticFiles() {
-	return gulp.src(settings.sources.staticFiles.map(sourcePath => path.join('node_modules/', sourcePath)), {base: 'node_modules/'})
-		.pipe(gulp.dest(isProdBuild() ? settings.destinations.prod.libs : settings.destinations.dev.libs));
-}
-
-/**
- * ESLint task:
- * Run `gulp lint` respectively `gulp lint --production`
- */
-export function lint() {
-	if (isProdBuild()) {
-		return gulp.src([...settings.sources.scripts, './*.js'])
-			.pipe(eslint())
-			.pipe(eslint.format())
-			.pipe(eslint.failAfterError());
-	}
-
-	/**
-	 * TODO: Run ESLint with --fix for dev build
-	 * Seems that isn’t possible to fix files in place with multiple inputs. See example.
-	 * Looks like we would need to use https://github.com/robrich/gulp-exec to execute ESLint (or xo) with the fix option.
-	 */
-	return gulp.src([...settings.sources.scripts, './*.js'])
-		.pipe(eslint())
-		.pipe(eslint.format())
-		.pipe(eslint.failAfterError())
-		.on('error', onError);
-}
-lint.description = '`gulp lint` lints JavaScript via ESLint';
-
-/**
- * Check dependencies with help of the node security platform
- */
-function security(done) {
-	if (isProdBuild()) {
-		nsp({package: path.join(__dirname, '/package.json')}, done);
-	} else {
-		done();
-	}
-}
-
-/**
- * Process HTML:
- * - Replaces references to JS and CSS for production build
- * - Remove comments for production build
- * - Simply copy HTML for dev build
- */
-function processHtml() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.markup)
-			.pipe(processhtml())
-			.pipe(htmlmin({removeComments: true, preserveLineBreaks: true, collapseWhitespace: true}))
-			.pipe(gulp.dest(settings.destinations.prod.markup));
-	}
-	return gulp.src(settings.sources.markup)
-		.pipe(changed(settings.destinations.dev.markup))
-		.pipe(gulp.dest(settings.destinations.dev.markup));
-}
-
-/**
- * Lint HTML with Bootlint
- */
-function lintBootstrap() {
-	return gulp.src(settings.sources.markup)
-		.pipe(bootlint({
-			stoponerror: isProdBuild(),
-			disabledIds: ['W005']
-		}));
-}
-
-/**
- * HTML validation using the Nu HTML Checker
- */
-function validateHtml() {
-	if (isProdBuild()) {
-		return gulp.src(settings.sources.markup)
-			.pipe(htmllint())
-			.pipe(gulp.dest(settings.destinations.dev.markup));
-	}
-	return gulp.src(settings.sources.markup)
-		.pipe(htmllint())
-		.on('error', onError)
-		.pipe(gulp.dest(settings.destinations.prod.markup));
-}
-
-/**
+ * Export imported tasks.
+ * ----------------------------------------------------------------------------
  * Test task:
  * Run `gulp test`, `gulp test --watch` or `gulp test --production` in CI to
  * make exit with a correct exit code when tests are failing
+ * ----------------------------------------------------------------------------
+ * ESLint task:
+ * Run `gulp lint` respectively `gulp lint --production`
  */
-export function test(done) {
-	if (args.watch) {
-		jest.runCLI({watch: true, config: pkgJson.jest}, '.', () => {});
-		done();
-	}
-
-	jest.runCLI({config: pkgJson.jest}, '.', result => {
-		if (isProdBuild() && !result.success) {
-			done();
-			process.exit(1);
-		}
-		done();
-	});
-}
-test.description = '`gulp test` runs unit test via Jest CLI';
-test.flags = {
-	'--production': ' exits with exit code 1 when tests are failing (CI)',
-	'-P': ' Alias for --production',
-	'--watch': ' runs unit test with Jests native watch option',
-	'-W': ' Alias for --watch'
-};
+export {test, lint};
 
 /**
- * Serve task:
- * Run `gulp serve` respectively `gulp serve --production`
- */
-export function serve(done) {
-	let baseDir = mainDirectories.dev;
-	if (isProdBuild()) {
-		baseDir = mainDirectories.dist;
-	}
-	server.init({
-		server: {
-			baseDir
-		}
-	});
-	done();
-}
-serve.description = '`gulp serve` serves the build (`server` directory)';
-serve.flags = {
-	'--production': ' serves production build (`dist` directory)',
-	'-P': ' Alias for --production'
-};
-
-//  Helper function to reload server
-function reload(done) {
-	server.reload();
-	done();
-}
-
-/**
- * Watch task:
+ * Define and export watch task:
  * Run `gulp watch` respectively `gulp watch --production`
  */
 export function watch() {
@@ -381,7 +59,7 @@ export function watch() {
 watch.description = '`gulp watch` watches for changes and runs tasks automatically';
 
 /**
- * Main build task:
+ * Define and export main build task:
  * Run `gulp build` respectively `gulp build --production`
  */
 export const build = gulp.series(
@@ -395,56 +73,15 @@ build.flags = {
 };
 
 /**
- * Bumps version in package.json.
- * Used in release task.
+ * Define and export default task:
+ * Run `gulp` respectively `gulp --production`
  */
-function bumpVersion() {
-	if (!hasBumpType()) {
-		onError(new Error(chalk.red('Please specify release type: gulp release --bump (major|minor|patch)')));
-	}
-
-	pkgJson.version = semver.inc(pkgJson.version, args.bump);
-
-	return gulp.src('./package.json')
-		.pipe(bump({type: args.bump}))
-		.on('error', onError)
-		.pipe(gulp.dest('./'))
-		.pipe(touch());
-}
+const dev = gulp.series(build, serve, watch);
+dev.description = '`gulp` will build, serve, watch for changes and reload server';
+export default dev;
 
 /**
- * Creates changelog.
- * Used in release task.
- */
-function createChangelog() {
-	return gulp.src('./CHANGELOG.md', {buffer: false})
-		.pipe(changelog({preset: 'angular'}))
-		.pipe(gulp.dest('./'));
-}
-
-/**
- * Commits changes.
- * Used in release task.
- */
-function commitChanges() {
-	return gulp.src('.')
-		.pipe(git.add())
-		.pipe(git.commit(`Release ${pkgJson.version}`));
-}
-
-/**
- * Creates Git tag.
- * Used in release task.
- */
-function createTag(done) {
-	git.tag(pkgJson.version, `Created tag for version: ${pkgJson.version}`, error => {
-		if (error) return onError(error);
-		done();
-	});
-}
-
-/**
- * Release task:
+ * Define and export release task:
  * Run `gulp release --bump major|minor|patch`
  */
 export const release = gulp.series(build, bumpVersion, createChangelog, commitChanges, createTag);
@@ -455,11 +92,3 @@ release.flags = {
 	'--bump patch': ' patch release (0.0.1). See http://semver.org',
 	'-B major|minor|patch': ' alias to --bump'
 };
-
-/**
- * Default task:
- * Run `gulp` respectively `gulp --production`
- */
-const dev = gulp.series(build, serve, watch);
-dev.description = '`gulp` will build, serve, watch for changes and reload server';
-export default dev;

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,6 +5,7 @@ import gutil from 'gulp-util';
 
 // Import settings
 import {settings} from './gulp/config';
+import {isProdBuild} from './gulp/commandLineArgs';
 
 // Import tasks
 import clean from './gulp/tasks/clean';
@@ -27,6 +28,12 @@ import createChangelog from './gulp/tasks/createChangelog';
 import commitChanges from './gulp/tasks/commitChanges';
 import createTag from './gulp/tasks/createTag';
 import validateHtml from './gulp/tasks/validateHtml';
+
+/**
+ * Print build target
+ */
+const buildTarget = isProdBuild() ? ' Production ' : ' Development ';
+console.log(chalk.yellow(`Build target: ${chalk.bold.inverse(buildTarget)}`));
 
 /**
  * Export imported tasks.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
     ]
   },
   "jest": {
+    "testPathIgnorePatterns": [
+      "<rootDir>/gulp/",
+      "<rootDir>/node_modules/"
+    ],
     "collectCoverage": true,
     "collectCoverageFrom": [
       "src/app/**/*.{js,jsx}",


### PR DESCRIPTION
I refactored the 💩 out of the gulpfile. 

The task which are put together with other ones still remains in the gulpfile.
Hope that makes sense for you.

Cheers