### PR TITLE
Delete browserify caches before build

### DIFF
--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,16 +1,29 @@
 import del from 'del';
+import path from 'path';
 
 import {mainDirectories} from '../config';
 import {isProdBuild} from '../commandLineArgs';
+import {clientCacheFile} from './clientScripts';
+import {vendorCacheFile} from './vendorScripts';
 
+const browserifyCache = [
+	path.join(__dirname, `/../../${clientCacheFile}`),
+	path.join(__dirname, `/../../${vendorCacheFile}`)
+];
 /**
  * Delete output directories
  */
 function clean() {
 	if (isProdBuild()) {
-		return del(mainDirectories.dist);
+		return del([
+			...browserifyCache,
+			mainDirectories.dist
+		]);
 	}
-	return del(mainDirectories.dev);
+	return del([
+		...browserifyCache,
+		mainDirectories.dev
+	]);
 }
 
 export default clean;

--- a/gulp/tasks/clientScripts.js
+++ b/gulp/tasks/clientScripts.js
@@ -11,15 +11,16 @@ import {settings} from '../config';
 import onError from '../onError';
 import {isProdBuild} from '../commandLineArgs';
 
-const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
-	.transform(babelify, {sourceMaps: true})
-	.external(settings.sources.externalJs);
-browserifyInc(b, {cacheFile: './.browserify-cache-client.json'});
+export const clientCacheFile = '.browserify-cache-client.json';
 
 /**
  * Bundle own JavaScript excluding libs defined in package.json → bootstrapKickstart.bundleExternalJS
  */
 function clientScripts() {
+	const b = browserify('./src/app/index.js', {...browserifyInc.args, debug: true})
+		.transform(babelify, {sourceMaps: true})
+		.external(settings.sources.externalJs);
+	browserifyInc(b, {cacheFile: clientCacheFile});
 
 	if (isProdBuild()) {
 		return b.bundle()

--- a/gulp/tasks/vendorScripts.js
+++ b/gulp/tasks/vendorScripts.js
@@ -10,13 +10,15 @@ import {settings} from '../config';
 import onError from '../onError';
 import {isProdBuild} from '../commandLineArgs';
 
+export const vendorCacheFile = '.browserify-cache-vendor.json';
+
 /**
  * Bundle JavaScript libs defined in package.json → bootstrapKickstart.bundleExternalJS
  */
 function vendorScripts() {
 	const b = browserify({...browserifyInc.args});
 	settings.sources.externalJs.forEach(dep => b.require(dep));
-	browserifyInc(b, {cacheFile: './.browserify-cache-vendor.json'});
+	browserifyInc(b, {cacheFile: vendorCacheFile});
 
 	if (isProdBuild()) {
 		return b.bundle()


### PR DESCRIPTION
Needed to make sure changes made in `.babelrc` will be applied.

Delete both caches (client, vendor). 