### PR TITLE
feat: Remove oldIE support 🎉

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "private": true,
   "dependencies": {
     "bootstrap-sass": "3.3.7",
-    "html5shiv": "3.7.3",
-    "jquery": "3.2.1",
-    "jquery-placeholder": "2.3.1",
-    "respond.js": "1.4.2"
+    "jquery": "3.2.1"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
@@ -108,10 +105,7 @@
       "bootstrap-sass"
     ],
     "includeStaticFiles": [
-      "bootstrap-sass/assets/fonts/**/*",
-      "html5shiv/dist/html5shiv-printshiv.min.js",
-      "respond.js/dest/respond.min.js",
-      "jquery-placeholder/jquery.placeholder.js"
+      "bootstrap-sass/assets/fonts/**/*"
     ]
   },
   "jest": {

--- a/src/handlebars/layouts/default.hbs
+++ b/src/handlebars/layouts/default.hbs
@@ -1,9 +1,5 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html lang="en" class="no-js ie lt-ie10 lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html lang="en" class="no-js ie lt-ie10 lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html lang="en" class="no-js ie lt-ie10 lt-ie9"> <![endif]-->
-<!--[if IE 9]>         <html lang="en" class="no-js ie lt-ie10"> <![endif]-->
-<!--[if gt IE 9]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
+<html lang="en" class="no-js">
 
 <head>
 	<!-- Meta, title, CSS, favicons, etc. -->
@@ -30,29 +26,12 @@
 	-->
 	<script>(function(h){h.className = h.className.replace('no-js', 'js')})(document.documentElement)</script>
 
-	<!-- HTML5 shim and Respond.js IE8 support for HTML5 elements and media queries. -->
-	<!--[if lt IE 9]>
-	<script src="libs/html5shiv/dist/html5shiv-printshiv.min.js"></script>
-	<script src="libs/respond.js/dest/respond.min.js"></script>
-	<![endif]-->
-
-	<!--[if lte IE 9]>
-	<script src="libs/jquery-placeholder/jquery.placeholder.js"></script>
-	<![endif]-->
-
 	<!-- Place favicon.ico and apple-touch-icon.png in the root directory. -->
 
 	<!-- Place anything custom after this. But put JS to the end of body. -->
 </head>
 
 <body>
-<!--[if lt IE 8]>
-    <p class="browsehappy">
-        You are using an <strong>outdated</strong> browser.
-        Please <a href="http://browsehappy.com/">upgrade your browser</a>
-        to improve your experience.
-    </p>
-<![endif]-->
 
 	<!-- begin: content -->
 	{{{contents}}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,7 +2227,7 @@ debug@0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
-debug@2, debug@2.6.4, debug@^2.1.3, debug@^2.6.3:
+debug@2, debug@2.6.4, debug@^2.1.3:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
   dependencies:
@@ -2251,7 +2251,7 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@2.X, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
+debug@2.X, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -2592,13 +2592,13 @@ encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
-end-of-stream@1.0.0, end-of-stream@^1.0.0:
+end-of-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
   dependencies:
     once "~1.3.0"
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.0.tgz#7a90d833efda6cfa6eac0f4949dbb0fad3a63206"
   dependencies:
@@ -4157,10 +4157,6 @@ html-tags@^1.0.0, html-tags@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.1.1.tgz#869f43859f12d9bdc3892419e494a628aa1b204e"
 
-html5shiv@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/html5shiv/-/html5shiv-3.7.3.tgz#d78a84a367bcb9a710100d57802c387b084631d2"
-
 htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
@@ -5016,10 +5012,6 @@ jpegtran-bin@^3.0.0:
     bin-wrapper "^3.0.0"
     logalot "^2.0.0"
 
-jquery-placeholder@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-placeholder/-/jquery-placeholder-2.3.1.tgz#6025a1241019c08a8fb3ab8ed076285c05ba5e91"
-
 jquery@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
@@ -5612,13 +5604,7 @@ longest@^1.0.0, longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
-  dependencies:
-    js-tokens "^3.0.0"
-
-loose-envify@tomashanacek/loose-envify:
+loose-envify@^1.0.0, loose-envify@tomashanacek/loose-envify:
   version "1.0.0"
   resolved "https://codeload.github.com/tomashanacek/loose-envify/tar.gz/274d08b592bab76b3a7ab099a669ccd1b4a7a34f"
   dependencies:
@@ -7188,10 +7174,6 @@ resp-modifier@6.0.2:
   dependencies:
     debug "^2.2.0"
     minimatch "^3.0.2"
-
-respond.js@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/respond.js/-/respond.js-1.4.2.tgz#fd5c07450acce6090916d8d090b86b672dd9748b"
 
 restore-cursor@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes #175

BREAKING CHANGE: Removing oldIE support means that we no longer add conditional classes to the `<html>` element to adress oldIEs, we’ve removed polyfills (html5shiv, respond.js, jquery-placeholder) and we’ve removed the message for oldIE users to upgrade their browser.